### PR TITLE
🛠 Tooling `.gitignore`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Hola Equipo,

Se añade en el proyecto el archivo `.gitatributes` para usar la nomenclatura de Unix, que es en la forma que trabaja git.
